### PR TITLE
Fixing typo in LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,4 +1,4 @@
-   Puppet Package Module
+   Puppet Amanda Module
 
    Copyright (C) 2012 Computer Action Team 
 


### PR DESCRIPTION
LICENSE file is for amanda not package
