### PR TITLE
puppet-amanda updated for SuSE based systems

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,6 +31,7 @@ class amanda::params {
       $homedir              = "/var/lib/amanda"
       $uid                  = "59500"
       $user                 = "amandabackup"
+      $comment              = "Amanda backup user"
       $shell                = "/bin/sh"
       $group                = "disk"
       $groups               = [ "backup", "tape" ]
@@ -51,6 +52,7 @@ class amanda::params {
       $homedir              = "/var/lib/amanda"
       $uid                  = "59500"
       $user                 = "amanda"
+      $comment              = "Amanda backup user"
       $shell                = "/bin/sh"
       $group                = "sys"
       $groups               = [ ]
@@ -68,6 +70,7 @@ class amanda::params {
       $homedir              = "/var/db/amanda"
       $uid                  = "59500"
       $user                 = "amanda"
+      $comment              = "Amanda backup user"
       $shell                = "/bin/sh"
       $group                = $operatingsystemrelease ? {
         /^[4567]|^8\.[10]/  => "operator", # FreeBSD versions < 8.2 suck
@@ -87,10 +90,28 @@ class amanda::params {
         "/usr/local/var/amanda/gnutar-lists",
       ]
     }
+    "OpenSuSE", "SLES", "SLED", "SuSE":  {
+      $homedir              = "/var/lib/amanda"
+      $uid                  = "37"
+      $user                 = "amanda"
+      $comment              = "Amanda admin"
+      $group                = "amanda"
+      $groups               = [ "tape" ]
+      $genericpackage        = "amanda"
+      $serverprovidesclient = true  # there's only one package on suse
+      $amandadpath          = "/usr/lib/amanda/amandad"
+      $amandaidxpath        = "/usr/lib/amanda/amindexd"
+      $amandatapedpath      = "/usr/lib/amanda/amidxtaped"
+      $amandadirectories    = [
+        "/tmp/amanda",
+        "/tmp/amanda/amandad",
+      ]
+    }
     default:   {
       $homedir              = "/var/lib/amanda"
       $uid                  = "59500"
       $user                 = "amandabackup"
+      $comment              = "Amanda backup user"
       $shell                = "/bin/sh"
       $group                = "backup"
       $groups               = [ ]

--- a/manifests/virtual.pp
+++ b/manifests/virtual.pp
@@ -15,7 +15,7 @@ class amanda::virtual {
       home    => $amanda::params::homedir,
       shell   => $amanda::params::shell,
       groups  => $amanda::params::groups,
-      comment => "Amanda backup user",
+      comment => $amanda::params::comment,
       tag     => "amanda_common";
   }
 


### PR DESCRIPTION
- Added support for SuSE systems, with defaults based on the
    distributed Amanda packages.
  - Added $comment variable to each $operatingsystem definition.
- virtual.pp
  - Added comment to @user setting it to $amanda::params::comment
    as definied in params.pp.
