### PR TITLE
Ignore .svn directory when recursively transferring amanda config to the client

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -56,7 +56,7 @@ define amanda::config (
     mode    => $mode,
     recurse => remote,
     source  => "puppet://$server/$configs_source/$config",
-	ignore  => ".svn"
+    ignore  => ".svn"
   }
 
 }


### PR DESCRIPTION
This change causes puppet to ignore the .svn subdir when recursing
the amanda config to the client. It may be useful to include other
revision control files in the ignore.
