### PR TITLE
Fixed locations for binaries on CentOS (for both x86_64 and i386)

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -84,7 +84,10 @@ class amanda::params {
       $client_package         = 'amanda-client'
       $server_package         = 'amanda-server'
       $server_provides_client = false
-      $amandad_path           = '/usr/sbin/amandad'
+      $amandad_path           = $::architecture ? {
+        x86_64 => '/usr/lib64/amanda/amandad',
+        i386   => '/usr/lib/amanda/amandad',
+      }
       $amandaidx_path         = $::architecture ? {
         x86_64 => '/usr/lib64/amanda/amindexd',
         i386   => '/usr/lib/amanda/amindexd',


### PR DESCRIPTION
The location of the amanda binaries was wrong in params.pp. I fixed that and added an architecture check as well since the binaries are in different places depending on the architecture.
