### PR TITLE
Release 1.0.0

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,3 +1,14 @@
+2013-09-29 Release 1.0.0
+
+Summary:
+
+Add disklist support for Amanda
+
+Backwards-incompatible changes:
+
+  - Changed dependency on ripienaar/concat to puppetlabs/concat
+  - Added dependency on stdlib
+
 0.1.7 - pdxcat/amanda - 2013/08/01
 
   547a444 Update dependencies to use puppetlabs/xinetd

--- a/Modulefile
+++ b/Modulefile
@@ -1,5 +1,5 @@
 name    'pdxcat-amanda'
-version '0.1.7'
+version '1.0.0'
 source 'https://github.com/pdxcat/puppet-module-amanda'
 author 'Computer Action Team'
 license 'Apache License 2.0'
@@ -8,6 +8,6 @@ description 'Amanda Module for Puppet'
 project_page 'https://github.com/pdxcat/puppet-module-amanda'
 
 ## Add dependencies, if any:
-dependency 'ripienaar/concat', '>= 0.1.0'
+dependency 'puppetlabs/concat', '>= 1.0.0'
 dependency 'puppetlabs/xinetd', '>= 1.2.0'
 dependency 'puppetlabs/stdlib', '>= 2.2.1'


### PR DESCRIPTION
Summary:

Add disklist support for Amanda

Backwards-incompatible changes:
- Changed dependency on ripienaar/concat to puppetlabs/concat
- Added dependency on stdlib
