### PR TITLE
set proper ownership/permission on disklist file

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -61,7 +61,11 @@ define amanda::config (
   }
 
   if $manage_dle == true {
-    concat { "$configs_directory_real/$config/disklist": }
+    concat { "$configs_directory_real/$config/disklist":
+        owner   => $owner_real,
+        group   => $group_real,
+        mode    => $mode,
+    }
     concat::fragment { "dle_header_$config":
         target  => "$configs_directory_real/$config/disklist",
         order   => 01,


### PR DESCRIPTION
ownership was not being set so they defaulted to root:root, now their being set appropriately.
