### PR TITLE
ssh host key imports:

### DIFF
--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -2,7 +2,7 @@ class amanda::client (
   $remote_user      = undef,
   $server           = "backup.$::domain",
   $xinetd           = true,
-  $import_host_keys = false,
+  $export_host_keys = false,
 ) {
   include amanda
   include amanda::params
@@ -33,7 +33,7 @@ class amanda::client (
     order   => '00';
   }
 
-  if ($import_host_keys) {
+  if ($export_host_keys) {
     ## export our ssh host keys
     @@sshkey { "${::clientcert}_amanda":
       ensure       => present,

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -8,7 +8,7 @@ class amanda::server (
   $owner                    = undef,
   $xinetd                   = true,
   $manage_dle               = false,
-  $import_host_keys         = false,
+  $export_host_keys         = false,
 ) {
   include amanda
   include amanda::params
@@ -64,7 +64,7 @@ class amanda::server (
     manage_dle               => $manage_dle,
   }
 
-  if ($import_host_keys) {
+  if ($export_host_keys) {
     ## import client ssh hosy keys into known_hosts
     SshKey <<| tag == 'amanda_client_host_keys' |>>
   }


### PR DESCRIPTION
manifests/client.pp: export the ssh host key for the client node.
manifetss/server.pp: import host keys from the client nodes.

Just a couple of more additions so ssh host keys from the client nodes get added to the known_hosts on the master to avoid having to import them manually
