### PR TITLE
amanda::config via puppet scheme url now optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,11 @@ amanda configs using puppet code. Rather, that legwork is still left up to the
 administrator, and the module will only ensure that the files which comprise
 the config are present on the server.
 
+If you need to create configs from templates or other sources, then by setting
+`manage_configs_source` to `false` will disable extraction via the mechanism
+below, you are then free to assign puppet file resources as appropriate to
+create your configs.
+
 Additional parameters are available for both the `amanda::server` and
 `amanda::client` classes which are not documented here. At present the only
 way to look up how to use them is to read the source.

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -5,6 +5,7 @@ define amanda::config (
   $manage_configs_directory = true,
   $manage_dle               = false,
   $configs_source           = 'amanda/server',
+  $manage_configs_source    = true,
   $owner                    = undef,
   $group                    = undef,
   $mode                     = '0644'
@@ -50,14 +51,23 @@ define amanda::config (
     }
   }
 
-  file { "${configs_directory_real}/${config}":
-    ensure  => $ensure_directory,
-    owner   => $owner_real,
-    group   => $group_real,
-    mode    => $mode,
-    recurse => remote,
-    source  => "puppet:///modules/${configs_source}/${config}",
-    ignore  => '.svn',
+  if $manage_configs_source {
+    file { "${configs_directory_real}/${config}":
+      ensure  => $ensure_directory,
+      owner   => $owner_real,
+      group   => $group_real,
+      mode    => $mode,
+      recurse => remote,
+      source  => "puppet:///modules/${configs_source}/${config}",
+      ignore  => '.svn',
+    }
+  } else {
+    file { "${configs_directory_real}/${config}":
+      ensure => $ensure_directory,
+      owner  => $owner_real,
+      group  => $group_real,
+      mode   => $mode,
+    }
   }
 
   if $manage_dle == true {

--- a/manifests/server.pp
+++ b/manifests/server.pp
@@ -1,14 +1,15 @@
 class amanda::server (
-  $configs                  = [],
-  $configs_directory        = undef,
-  $manage_configs_directory = true,
-  $configs_source           = 'modules/amanda/server/example',
-  $mode                     = '0644',
-  $group                    = undef,
-  $owner                    = undef,
-  $xinetd                   = true,
-  $manage_dle               = false,
-  $export_host_keys         = false,
+  $configs                       = [],
+  $configs_directory             = undef,
+  $manage_configs_directory      = true,
+  Boolean $manage_configs_source = true,
+  $configs_source                = 'modules/amanda/server/example',
+  $mode                          = '0644',
+  $group                         = undef,
+  $owner                         = undef,
+  $xinetd                        = true,
+  $manage_dle                    = false,
+  $export_host_keys              = false,
 ) {
   include ::amanda
   include ::amanda::params
@@ -57,6 +58,7 @@ class amanda::server (
     ensure                   => present,
     manage_configs_directory => $manage_configs_directory,
     configs_directory        => $configs_directory,
+    manage_configs_source    => $manage_configs_source,
     configs_source           => $configs_source,
     owner                    => $owner_real,
     group                    => $group_real,
@@ -65,7 +67,7 @@ class amanda::server (
   }
 
   if ($export_host_keys) {
-    ## import client ssh hosy keys into known_hosts
+    ## import client ssh host keys into known_hosts
     SshKey <<| tag == 'amanda_client_host_keys' |>>
   }
 


### PR DESCRIPTION
Hi,

The use-case for this PR is the requirement to maintain each amanda config file via a template instead of pulling the whole config tree from a puppet:// scheme URL that is maybe in a different module.

By setting ‘manage_configs_source’ to false, the module releases concern about the config file and allows the file resource to be defined by other means.

I believe this change to be non-breaking as existing behaviour is maintained by default, and may lay the groundwork for more comprehensive config management for the future.

Regards,
Pete.
