### PR TITLE
Support puppetlabs/concat 4.2.1 and puppetlabs/xinetd 3.0.0

### DIFF
--- a/manifests/amandahosts.pp
+++ b/manifests/amandahosts.pp
@@ -9,7 +9,6 @@ define amanda::amandahosts (
   realize(Concat["${amanda::params::homedir}/.amandahosts"])
 
   concat::fragment { "amanda::amandahosts/${title}":
-    ensure  => $ensure,
     target  => "${amanda::params::homedir}/.amandahosts",
     content => "${content}\n",
     order   => $order;

--- a/manifests/disklist.pp
+++ b/manifests/disklist.pp
@@ -16,7 +16,6 @@ define amanda::disklist (
     validate_string($disk)
 
     @@concat::fragment { "amanda::disklist/${::fqdn}/${title}":
-        ensure  => $ensure,
         target  => "${amanda::params::configs_directory}/${config}/disklist",
         order   => $order,
         content => "${::fqdn} ${disk} ${diskdevice} ${dumptype} ${spindle} ${interface}\n",

--- a/metadata.json
+++ b/metadata.json
@@ -14,11 +14,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.5 < 3.0.0"
+      "version_requirement": ">= 1.2.5 < 5.0.0"
     },
     {
       "name": "puppetlabs/xinetd",
-      "version_requirement": ">= 2.0.0 < 3.0.0"
+      "version_requirement": ">= 2.0.0 < 4.0.0"
     },
     {
       "name": "puppetlabs/stdlib",


### PR DESCRIPTION
#### Pull Request (PR) description
The Amanda module lags behind in supporting the latest puppetlabs/concat and puppetlabs/xinetd. This blocks the install of other modules which need more up to date concat/xinetd releases.

#### This Pull Request (PR) fixes the following issues
-