### PR TITLE
Fix pull request #63 (Support puppetlabs/concat 4)

### DIFF
--- a/manifests/amandahosts.pp
+++ b/manifests/amandahosts.pp
@@ -8,9 +8,11 @@ define amanda::amandahosts (
 
   realize(Concat["${amanda::params::homedir}/.amandahosts"])
 
-  concat::fragment { "amanda::amandahosts/${title}":
-    target  => "${amanda::params::homedir}/.amandahosts",
-    content => "${content}\n",
-    order   => $order;
+  if $ensure == present {
+    concat::fragment { "amanda::amandahosts/${title}":
+      target  => "${amanda::params::homedir}/.amandahosts",
+      content => "${content}\n",
+      order   => $order;
+    }
   }
 }

--- a/manifests/disklist.pp
+++ b/manifests/disklist.pp
@@ -15,10 +15,12 @@ define amanda::disklist (
     validate_string($config)
     validate_string($disk)
 
-    @@concat::fragment { "amanda::disklist/${::fqdn}/${title}":
-        target  => "${amanda::params::configs_directory}/${config}/disklist",
-        order   => $order,
-        content => "${::fqdn} ${disk} ${diskdevice} ${dumptype} ${spindle} ${interface}\n",
-        tag     => 'amanda_dle',
+    if $ensure == 'present' {
+        @@concat::fragment { "amanda::disklist/${::fqdn}/${title}":
+            target  => "${amanda::params::configs_directory}/${config}/disklist",
+            order   => $order,
+            content => "${::fqdn} ${disk} ${diskdevice} ${dumptype} ${spindle} ${interface}\n",
+            tag     => 'amanda_dle',
+        }
     }
 }


### PR DESCRIPTION
#### Pull Request (PR) description

Pull request #63 added support for puppetlabs/concat 4.*. The change ignores the ensure attribute for `amanda::amandahosts` and `amanda::disklist`. This PR adheres `$ensure = absent` again.
