### PR TITLE
Fix stray 'directory_mode' reference left by bbaabd4

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -47,7 +47,7 @@ define amanda::config (
       path   => $configs_directory_real,
       owner  => $owner_real,
       group  => $group_real,
-      mode   => $::directory_mode,
+      mode   => $mode,
     }
   }
 


### PR DESCRIPTION
<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description
    Commit bbaabd4 (in May 2012) replaced most references to "$directory_mode" with "$mode", but the one on manifests/config.pp:48 was missed.
    Commit 6d6c069e (in Sep 2014), while attempting to address lint errors, erroneously changed the unreferenced "$directory_mode" to the global "$::directory_mode".
    I believe this PR fixes the issue properly by changing "$::directory_mode" to "$mode".

#### This Pull Request (PR) fixes the following issues
n/a
