### PR TITLE
Fix disklist with multiple configs

### DIFF
--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -81,6 +81,8 @@ define amanda::config (
       order   => '01',
       content => "# Managed by puppet\n",
     }
-    Concat::Fragment <<| tag == 'amanda_dle' |>> { target => "${configs_directory_real}/${config}/disklist" }
+    Concat::Fragment <<| tag == 'amanda_dle' and target == "${configs_directory_real}/${config}/disklist" |>> {
+      target => "${configs_directory_real}/${config}/disklist"
+    }
   }
 }


### PR DESCRIPTION
#### Pull Request (PR) description
When disklists are managed and multiple configs are active, the disks are written in the wrong disklist file. Filtering on the target makes the disks go to the right disklist file.

#### This Pull Request (PR) fixes the following issues
References (#12)